### PR TITLE
(Chore) Contracts should use master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Contracts"]
 	path = packages/contracts
 	url = https://github.com/GoodDollar/GoodContracts.git
-	branch = beta
+	branch = master
 [submodule "Server"]
 	path = packages/server
 	url = https://github.com/GoodDollar/GoodServer.git


### PR DESCRIPTION
# Description

Phase0 contracts should be used by default
We have to switch default branch for contracts to master in master-submodules command on bootstrap

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [X] PR title matches follow: (Feature|Bug|Chore) Task Name
- [X] My code follows the style guidelines of this project
- [X] I have followed all the instructions described in the initial task (check Definitions of Done)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request ( for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes
